### PR TITLE
Avoid HPEiLOCmdlets 5.0.0.0

### DIFF
--- a/PowerShell/Onboarding/Prepare-and-Connect-iLOs-to-COM-v2.ps1
+++ b/PowerShell/Onboarding/Prepare-and-Connect-iLOs-to-COM-v2.ps1
@@ -460,7 +460,7 @@ If (-not (Get-Module HPEiLOCmdlets -ListAvailable)) {
     Write-Host "HPEiLOCmdlets module not found, installing now..."
 
     Try {
-        Install-Module -Name HPEiLOCmdlets -Force -AllowClobber -AcceptLicense -ErrorAction Stop
+        Install-Module -Name HPEiLOCmdlets -RequiredVersion 4.4.0.0 -Force -AllowClobber -AcceptLicense -ErrorAction Stop
     }
     catch {
         $_
@@ -469,21 +469,21 @@ If (-not (Get-Module HPEiLOCmdlets -ListAvailable)) {
     }
 }
 else {
-    $installedModuleVersion = [version](Get-Module HPEiLOCmdlets -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Version)
-    $latestVersion = [version](Find-Module -Name HPEiLOCmdlets | Select-Object -ExpandProperty Version)
+    # $installedModuleVersion = [version](Get-Module HPEiLOCmdlets -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Version)
+    # $latestVersion = [version](Find-Module -Name HPEiLOCmdlets | Select-Object -ExpandProperty Version)
 
-    if ($installedModuleVersion -lt $latestVersion) {
-        "Version of HPEiLOCmdlets module installed '{0}' is outdated. Updating now to '{1}'..." -f $installedModuleVersion, $latestVersion | Write-Host -f Yellow
+    # if ($installedModuleVersion -lt $latestVersion) {
+    #     "Version of HPEiLOCmdlets module installed '{0}' is outdated. Updating now to '{1}'..." -f $installedModuleVersion, $latestVersion | Write-Host -f Yellow
         
-        Try {
-            Install-Module -Name HPEiLOCmdlets -Force -AllowClobber -AcceptLicense -ErrorAction Stop
-        }
-        catch {
-            $_
-            Read-Host "Hit return to close"
-            exit
-        }
-    }
+    #     Try {
+    #         Install-Module -Name HPEiLOCmdlets -Force -AllowClobber -AcceptLicense -ErrorAction Stop
+    #     }
+    #     catch {
+    #         $_
+    #         Read-Host "Hit return to close"
+    #         exit
+    #     }
+    # }
 }
 
 # Check if HPECOMCmdlets module is installed and ensure the latest version is installed

--- a/PowerShell/Onboarding/Prepare-and-Connect-iLOs-to-COM-v2.ps1
+++ b/PowerShell/Onboarding/Prepare-and-Connect-iLOs-to-COM-v2.ps1
@@ -469,21 +469,35 @@ If (-not (Get-Module HPEiLOCmdlets -ListAvailable)) {
     }
 }
 else {
-    # $installedModuleVersion = [version](Get-Module HPEiLOCmdlets -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Version)
-    # $latestVersion = [version](Find-Module -Name HPEiLOCmdlets | Select-Object -ExpandProperty Version)
+    $installedModuleVersion = [version](Get-Module HPEiLOCmdlets -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1 | Select-Object -ExpandProperty Version)
+    $latestVersion = [version](Find-Module -Name HPEiLOCmdlets -RequiredVersion 4.4.0.0 | Select-Object -ExpandProperty Version)
 
-    # if ($installedModuleVersion -lt $latestVersion) {
-    #     "Version of HPEiLOCmdlets module installed '{0}' is outdated. Updating now to '{1}'..." -f $installedModuleVersion, $latestVersion | Write-Host -f Yellow
+    if ($installedModuleVersion -lt $latestVersion) {
+        "Version of HPEiLOCmdlets module installed '{0}' is outdated. Updating now to '{1}'..." -f $installedModuleVersion, $latestVersion | Write-Host -f Yellow
         
-    #     Try {
-    #         Install-Module -Name HPEiLOCmdlets -Force -AllowClobber -AcceptLicense -ErrorAction Stop
-    #     }
-    #     catch {
-    #         $_
-    #         Read-Host "Hit return to close"
-    #         exit
-    #     }
-    # }
+        Try {
+            Install-Module -Name HPEiLOCmdlets -RequiredVersion 4.4.0.0 -Force -AllowClobber -AcceptLicense -ErrorAction Stop
+        }
+        catch {
+            $_
+            Read-Host "Hit return to close"
+            exit
+        }
+    }
+
+    if ($installedModuleVersion -gt $latestVersion) {
+        "Version of HPEiLOCmdlets module installed '{0}' is not supported yet. Downgrading now to '{1}'..." -f $installedModuleVersion, $latestVersion | Write-Host -f Yellow
+        
+        Try {
+            Uninstall-Module -Name HPEiLOCmdlets -RequiredVersion $installedModuleVersion -Force -ErrorAction Stop
+            Install-Module -Name HPEiLOCmdlets -RequiredVersion 4.4.0.0 -Force -AllowClobber -AcceptLicense -ErrorAction Stop
+        }
+        catch {
+            $_
+            Read-Host "Hit return to close"
+            exit
+        }
+    }
 }
 
 # Check if HPECOMCmdlets module is installed and ensure the latest version is installed


### PR DESCRIPTION
HPEiLOCmdlets 5.0.0.0 breaks Connect-HPEiLO when using the -Credential parameter, which is what this script uses